### PR TITLE
Grant autopatrol right to VIP users

### DIFF
--- a/mediawiki/settings/includes/Permissions.php
+++ b/mediawiki/settings/includes/Permissions.php
@@ -6,6 +6,7 @@ $wgGroupPermissions['*']['createaccount'] = false;
 $wgGroupPermissions['vip']['edit'] = true;
 $wgGroupPermissions['vip']['createpage'] = true;
 $wgGroupPermissions['vip']['createaccount'] = true;
+$wgGroupPermissions['vip']['autopatrol'] = true;
 # user css/ js
 $wgAllowUserCss = true;
 $wgAllowUserJs = true;


### PR DESCRIPTION
This change is not really necessary, because patrolling doesn't actually affect anything here, but it makes a ❗ appear next to unpatrolled edits in recent changes (and someone has to manually click on "mark as patrolled" on the edit diff page for every one of these).
VIP users probably aren't making edits that would need to be verified through this system, so I think it makes sense to grant them the `autopatrol` right.

https://discord.com/channels/603643120093233162/908441365879337080/1317605705297035294