### PR TITLE
Fix issues with Vector dark mode

### DIFF
--- a/mediawiki/styles/Vector.css
+++ b/mediawiki/styles/Vector.css
@@ -1,4 +1,4 @@
-/* https://github.com/StylishThemes/Wikipedia-Dark/*/
+/* https://github.com/StylishThemes/Wikipedia-Dark/ */
 :root {
   --base-color: #66b3ff;
   --darker-base: #0b437a;
@@ -781,6 +781,7 @@ td[style="background: #8AB0FF;"], tr[style*="background:#E5D8C0;"] > td {
 }
 figure[typeof*="mw"] > figcaption {
   border: 1px solid var(--gray-5);
+  /* mschae23 addition */ border-top: none;
   background-color: var(--gray-3);
 }
 .oo-ui-menuOptionWidget.oo-ui-widget-enabled.oo-ui-optionWidget,
@@ -799,7 +800,8 @@ figure[typeof*="mw"] > figcaption {
 }
 /* text selection */
 ::selection, ::-moz-selection {
-  background-color: var(--base-color) !important;
+  /*background-color: var(--base-color) !important;*/
+  background-color: #2ef3 !important;
   color: var(--white) !important;
 }
 /*** Background ***/
@@ -930,7 +932,7 @@ table[style*="background-color: #f9f9f9; border: 1px solid #aaa;"] {
 }
 input[type="search"]#searchInput:focus, #simpleSearch:hover #searchInput:focus {
   -webkit-box-shadow: none;
-          box-shadow: none;
+  box-shadow: none;
   border-color: var(--base-color) !important;
 }
 .oo-ui-inputWidget-input, .oo-ui-checkboxInputWidget-checkIcon {
@@ -1020,6 +1022,11 @@ span.mw-redirectedfrom, span.subpages, .mw-parser-output > p,
 .oo-ui-tagItemWidget.oo-ui-widget-enabled.oo-ui-flaggedElement-invalid:focus {
   border-color: var(--red-2);
   box-shadow: inset 0 0 0 1px var(--red-2);
+}
+/* mschae23 addition */
+.mw-rcfilters-container .mw-rcfilters-ui-filterTagMultiselectWidget.oo-ui-widget-enabled .oo-ui-tagMultiselectWidget-handle {
+  border: 1px solid var(--gray-4);
+  border-bottom: none;
 }
 .oo-ui-tagItemWidget.oo-ui-widget-enabled:focus,
 .oo-ui-tagMultiselectWidget.oo-ui-widget-enabled.oo-ui-tagMultiselectWidget-inlined.oo-ui-tagMultiselectWidget-focus .oo-ui-tagMultiselectWidget-handle {
@@ -1525,10 +1532,13 @@ table[style*="border:1px solid #a2a9b1"] td,
 .oo-ui-tagItemWidget, .wikiEditor-ui-toolbar .page-table td {
   border-color: var(--gray-5);
 }
-.mw-rcfilters-ui-filterTagMultiselectWidget.oo-ui-widget-enabled .oo-ui-tagMultiselectWidget-handle,
-.mw-rcfilters-ui-filterTagMultiselectWidget-views-select-widget.oo-ui-widget,
+.mw-rcfilters-container .mw-rcfilters-ui-filterTagMultiselectWidget-views-select-widget.oo-ui-widget,
 .ui-dialog, .mw-parser-output table.dmbox {
-  border-color: var(--gray-4);
+  /* mschae23 change */ border: 1px solid var(--gray-4);
+}
+/* mschae23 addition */
+.mw-rcfilters-container .mw-rcfilters-ui-filterTagMultiselectWidget-views-select-widget.oo-ui-widget {
+  border-left: none;
 }
 .oo-ui-buttonElement-framed.oo-ui-widget-enabled > .oo-ui-buttonElement-button,
 .oo-ui-buttonElement-framed.oo-ui-widget-disabled > .oo-ui-buttonElement-button {
@@ -2188,11 +2198,11 @@ div[style*="background-color: #F9F9F9;"] {
 }
 .tux-pagemode-status.fuzzy {
   background-image: linear-gradient(transparent, transparent),
-                        url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2233.389%22 height=%2222.857%22 viewBox=%220 0 33.389 22.857%22%3E %3Cpath fill=%22%234b380d%22 d=%22M0 0h25.922l7.467 11.43-7.468 11.428H0V0z%22/%3E %3Cpath fill=%22%23999%22 d=%22M17.98 4.357c-4.06 0-7.374 3.316-7.374 7.375 0 4.06 3.315 7.375 7.375 7.375 4.06 0 7.376-3.316 7.376-7.375 0-4.06-3.316-7.375-7.375-7.375zm0 1.768c3.105 0 5.608 2.504 5.608 5.607s-2.504 5.607-5.607 5.607c-3.102 0-5.606-2.505-5.606-5.608 0-3.103 2.504-5.607 5.607-5.607z%22/%3E %3Cpath fill=%22%23999%22 d=%22M17.19 7.223v5.761h3.427v-1.21H18.4V7.223h-1.21z%22/%3E %3C/svg%3E");
+  url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2233.389%22 height=%2222.857%22 viewBox=%220 0 33.389 22.857%22%3E %3Cpath fill=%22%234b380d%22 d=%22M0 0h25.922l7.467 11.43-7.468 11.428H0V0z%22/%3E %3Cpath fill=%22%23999%22 d=%22M17.98 4.357c-4.06 0-7.374 3.316-7.374 7.375 0 4.06 3.315 7.375 7.375 7.375 4.06 0 7.376-3.316 7.376-7.375 0-4.06-3.316-7.375-7.375-7.375zm0 1.768c3.105 0 5.608 2.504 5.608 5.607s-2.504 5.607-5.607 5.607c-3.102 0-5.606-2.505-5.606-5.608 0-3.103 2.504-5.607 5.607-5.607z%22/%3E %3Cpath fill=%22%23999%22 d=%22M17.19 7.223v5.761h3.427v-1.21H18.4V7.223h-1.21z%22/%3E %3C/svg%3E");
 }
 .tux-workflow-status-selector li.selected {
   background-image: linear-gradient(transparent, transparent),
-                        url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2215%22 height=%2215%22 viewBox=%220 0 15 15%22%3E %3Cpath fill=%22%23999%22 d=%22M10.765 1.078l-5.188 8.938-2.03-1.5L1.95 10.64l3.25 2.407 1.188.875.75-1.28 5.906-10.25-2.28-1.314z%22/%3E %3C/svg%3E");
+  url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2215%22 height=%2215%22 viewBox=%220 0 15 15%22%3E %3Cpath fill=%22%23999%22 d=%22M10.765 1.078l-5.188 8.938-2.03-1.5L1.95 10.64l3.25 2.407 1.188.875.75-1.28 5.906-10.25-2.28-1.314z%22/%3E %3C/svg%3E");
   color: var(--gray-a) !important;
 }
 .grid .tux-message-editor .close {
@@ -2241,7 +2251,7 @@ div[style*="background-color: #F9F9F9;"] {
 }
 .tux-loading-indicator {
   background-image: linear-gradient(transparent, transparent),
-                        url("data:image/svg+xml,<?xml version='1.0' standalone='no'?><svg version='1.0' xmlns='http://www.w3.org/2000/svg' width='34px' height='34px' viewBox='0 0 34.000000 34.000000' preserveAspectRatio='xMidYMid meet'><g transform='translate(0.000000,34.000000) scale(0.100000,-0.100000)' fill='rgb(/*[[base-color-rgb]]*/)' stroke='none'><path d='M285 103 c-16 -29 -32 -43 -75 -60 -48 -19 -51 -22 -25 -23 39 0 90 32 115 72 21 35 25 48 13 48 -5 0 -17 -17 -28 -37z'/></g></svg>");
+  url("data:image/svg+xml,<?xml version='1.0' standalone='no'?><svg version='1.0' xmlns='http://www.w3.org/2000/svg' width='34px' height='34px' viewBox='0 0 34.000000 34.000000' preserveAspectRatio='xMidYMid meet'><g transform='translate(0.000000,34.000000) scale(0.100000,-0.100000)' fill='rgb(/*[[base-color-rgb]]*/)' stroke='none'><path d='M285 103 c-16 -29 -32 -43 -75 -60 -48 -19 -51 -22 -25 -23 39 0 90 32 115 72 21 35 25 48 13 48 -5 0 -17 -17 -28 -37z'/></g></svg>");
 }
 .tux-dropdown-menu .unchangeable, .tux-message-editor .shortcutinfo,
 .grid .tux-message-editor .messagekey, .tux-message-selector label {
@@ -2948,6 +2958,7 @@ th, td:not(:hover), h1, h3, h4, h5, h6, ul, li, select, .mw-body, .toc, #toc,
 table.fmbox, .wikiEditor-ui .wikiEditor-ui-view,
 .wikiEditor-ui-toolbar .sections .section,
 .wikiEditor-ui-toolbar .group-search, .wikiEditor-ui-toolbar .group,
+  /* mschae23 addition */ .wikiEditor-ui-toolbar .section-secondary .group,
 .wikiEditor-ui-toolbar .group .tool-select,
 .wikiEditor-ui-toolbar .group .tool-select .options,
 .wikiEditor-ui-toolbar .page-characters div span, .oo-ui-panelLayout-framed,
@@ -3424,8 +3435,8 @@ tr + tr > .navbox-list {
 }
 table.navbox {
   -webkit-box-shadow: 3px 3px 6px var(--gray-28);
-      -moz-box-shadow: 3px 3px 6px var(--gray-28);
-          box-shadow: 3px 3px 6px var(--gray-28);
+  -moz-box-shadow: 3px 3px 6px var(--gray-28);
+  box-shadow: 3px 3px 6px var(--gray-28);
 }
 /*** Text ***/
 .wikitable tr:not([style*="color:black" i]) th:not([style*="color: black" i]):not([style*="FF"]):not([style*="77"]),
@@ -3528,7 +3539,7 @@ a.link-box:hover small bdi, a.link-box:hover small span {
 }
 .imeselector-menu .ime-checked {
   background-image: linear-gradient(transparent, transparent),
-                        url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%229%22%3E%3Cpath d=%22M11.226.257l-6.718 6.453-2.699-2.575-1.292 1.302c1.33 1.273 2.65 2.557 3.99 3.821 2.654-2.591 5.337-5.153 8.01-7.726z%22 fill=%22%23ccc%22/%3E%3C/svg%3E");
+  url("data:image/svg+xml,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 width=%2212%22 height=%229%22%3E%3Cpath d=%22M11.226.257l-6.718 6.453-2.699-2.575-1.292 1.302c1.33 1.273 2.65 2.557 3.99 3.821 2.654-2.591 5.337-5.153 8.01-7.726z%22 fill=%22%23ccc%22/%3E%3C/svg%3E");
 }
 .wikEdButton, .wikEdButtonDummy, .wikEdButtonChecked, .wikEdButtonUnchecked {
   background-color: transparent;
@@ -3922,7 +3933,7 @@ img[src*=".svg"]:not([src*="check"])[height="18"]:not([src*="oyal"]):not([alt*="
 #pt-notifications-alert .mw-echo-notifications-badge,
 img.mwe-math-fallback-image-display, #cnotice-toggle-icon {
   -webkit-filter: invert(100%) !important;
-          filter: invert(100%) !important;
+  filter: invert(100%) !important;
   background-color: transparent !important;
 }
 img.mwe-math-fallback-image-inline, .oo-ui-indicator-required {
@@ -4069,6 +4080,22 @@ a.image img[src*="Dagger-and-double-dagger-in-times-new-roman"] {
 #footer-icons img {
   filter: brightness(70%);
 }
+/* mschae23 addition */
+#footer-icons a {
+  background: none;
+}
+/* mschae23 addition */
+#footer-icons .cdx-button {
+  border: none;
+}
+/* mschae23 addition */
+#footer-poweredbyico {
+  background-color: var(--gray-c);
+  padding-top: 0.1em;
+  padding-bottom: 0.1em;
+  margin-top: 0.4em;
+  margin-bottom: 0.9em;
+}
 img[alt="The Signpost"] {
   filter: invert(60%);
 }
@@ -4084,6 +4111,13 @@ img[alt="The Signpost"] {
 }
 #mw-indicator-mw-helplink a {
   background-image: url('data:image/svg+xml;utf-8,%3Csvg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="m12.001 2.085c-5.478 0-9.916 4.438-9.916 9.916 0 5.476 4.438 9.914 9.916 9.914 5.476 0 9.914-4.438 9.914-9.914 0-5.478-4.438-9.916-9.914-9.916zm0.001 18c-4.465 0-8.084-3.619-8.084-8.083 0-4.465 3.619-8.084 8.084-8.084 4.464 0 8.083 3.619 8.083 8.084 0 4.464-3.619 8.083-8.083 8.083z" fill="%23888"/%3E%3Cpath d="m11.766 6.688c-2.5 0-3.219 2.188-3.219 2.188l1.411 0.854s0.298-0.791 0.901-1.229c0.516-0.375 1.625-0.625 2.219 0.125 0.701 0.885-0.17 1.587-1.078 2.719-0.953 1.186-1 3.655-1 3.655h1.969s0.135-2.318 1.041-3.381c0.604-0.707 1.443-1.338 1.443-2.494s-1.187-2.437-3.687-2.437zm-0.766 9.312h2v2h-2v-2z" fill="%23888"/%3E%3C/svg%3E');
+  /* mschae23 addition */ background-repeat: no-repeat;
+}
+/* mschae23 addition */
+#mw-indicator-mw-helplink a .mw-helplink-icon {
+  -webkit-mask-image: none;
+  mask-image: none;
+  background-color: unset;
 }
 .cx-campaign-contributionsmenu li.cx-campaign-contributions a {
   background-image: url('data:image/svg+xml;utf-8,%3Csvg viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg"%3E%3Cpath d="m10 11c-5.92 0-8 3-8 5v3h16v-3c0-2-2.08-5-8-5z" fill="%23888"/%3E%3Ccircle cx="10" cy="5.5" r="4.5" fill="%23888"/%3E%3C/svg%3E%0A');
@@ -4256,4 +4290,87 @@ table.cmbox-notice {
 }
 .mw-parser-output .current-events-sidebar > div:not(.mw-collapsible-content) {
   background-color:initial;
+}
+
+/* mschae23 additions */
+.mw-enhancedchanges-checkbox + * .mw-enhancedchanges-arrow {
+  background-color: var(--gray-c);
+}
+
+.cdx-message:not(.cdx-message--error) {
+  color: var(--white);
+}
+.cdx-message--warning {
+  background-color: #3d3205;
+}
+
+#mw-head .vector-menu-dropdown .vector-menu-heading {
+  color: inherit;
+}
+.vector-menu-dropdown .vector-menu-heading::after {
+  filter: invert();
+}
+
+@media screen {
+  figure[typeof~="mw:File/Thumb"] > :not(figcaption) .mw-file-element, figure[typeof~="mw:File/Frame"] > :not(figcaption) .mw-file-element {
+    border: 1px solid var(--gray-5);
+  }
+  figure[typeof~="mw:File/Thumb"] > .mw-file-description, figure[typeof~="mw:File/Frame"] > .mw-file-description {
+    background-color: var(--gray-3);
+  }
+  figure[typeof~="mw:File/Thumb"], figure[typeof~="mw:File/Frame"] {
+    border: 1px solid var(--gray-5);
+    border-bottom: none;
+  }
+}
+
+.wikiEditor-ui-toolbar .section-secondary .group {
+  border-right: none;
+}
+
+.mw-changeslist-legend {
+  background-color: var(--gray-2);
+  border-color: var(--gray-4);
+}
+
+#preferences .mw-htmlform-submit-buttons {
+  background-color: var(--gray-2);
+  border-top: 1px solid var(--gray-5);
+}
+
+/* mschae23 addition: image captions */
+figure[typeof~="mw:File/Thumb"] > figcaption, figure[typeof~="mw:File/Frame"] > figcaption {
+  padding: 6px;
+}
+
+/* mschae23 additions: CodeMirror */
+.cm-editor .cm-gutters {
+  background-color: var(--gray-28);
+  border-right-color: var(--gray-5);
+  color: var(--gray-a);
+}
+.ͼ2 .cm-gutters {
+  border-right: 1px solid var(--gray-5);
+}
+.ͼ2 .cm-content, .ͼ4 .cm-line {
+  caret-color: var(--white); !important;
+}
+.cm-editor .cm-cursor {
+  border-left-color: var(--white);
+}
+.cm-tooltip-fold {
+  display: none;
+}
+.ͼ4 .cm-line ::selection, .ͼ4 .cm-line::selection {
+  background-color: #2ef3 !important;
+  color: var(--white) !important;
+}
+/* mschae23 additions: Multimedia viewer */
+.cdx-button:enabled, .cdx-button.cdx-button--fake-button--enabled {
+  background-color: var(--gray-3);
+  color: var(--gray-c);
+  border-color: var(--gray-5);
+}
+.cdx-button:enabled .cdx-button__icon, .cdx-button.cdx-button--fake-button--enabled .cdx-button__icon {
+  background-color: var(--gray-c);
 }


### PR DESCRIPTION
I've been marking my changes with my username so they're easier to keep track of, I hope that's fine. This also contains the selection color change by mini-bomba, because I based this off the version that was on the wiki.

There are also a few formatting changes here that I couldn't keep my IDE from making, so I guess they're also included.

I didn't touch mobile, but as far as I can tell, Minerva Neue actually has a native dark mode now – though it seems to be experimental, but it may still be worth looking into whether it's possible to just enable that by default and remove the overrides here.